### PR TITLE
Fix landing page sign in and sign up buttons hidden bug

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,7 +18,5 @@
         <a href="signup.html">Sign up</a>
     </div>
 </header>
-<script type="application/javascript" src="scripts/jquery-3.3.1.js"></script>
-<script type="application/javascript" src="scripts/app.js"></script>
 </body>
 </html>

--- a/scripts/app.js
+++ b/scripts/app.js
@@ -9,8 +9,8 @@ const setToken = (value) => localStorage.setItem('auth-token', value);
 const clearToken = () => localStorage.removeItem('auth-token');
 
 const checkAuth = (uri) => {
-    // the landing, sign up and sign in pages are the only unprotected pages
-    if (uri === 'index.html' || uri === 'signup.html' || uri === 'signin.html') {
+    // the sign up and sign in pages are not protected pages
+    if (uri === 'signup.html' || uri === 'signin.html') {
         return
     }
     if (!getToken()) {
@@ -327,10 +327,6 @@ const loadPage = (uri, url) => {
     clearMessages();
     // hide any error or success messages when the user starts typing
     $('input').keyup(() => clearMessages());
-    // nothing changes for the landing
-    if (uri === 'index.html') {
-        return
-    }
     const token = getToken();
     if (uri === 'signup.html' || uri === 'signin.html') {
         if (token) {


### PR DESCRIPTION
This PR fixes landing page sign in and sign up buttons hidden bug. The sign in and sign out buttons on the landing are being hidden immediately the page loads. This is being caused by the logic that is used to hide the same buttons on the navigation bar once the user is logged in. This can be manually tested by visiting [MyDiaryFrontend](https://mutaimwiti.github.io/mydiary/).